### PR TITLE
feat: add delay_ms key alternative for add on ECU

### DIFF
--- a/src/tier4_camera_sync_doctor.cpp
+++ b/src/tier4_camera_sync_doctor.cpp
@@ -217,6 +217,10 @@ std::optional<int> Tier4CameraSyncDoctor::parseReadoutDelayParamFile(const std::
 
   std::string key = "delay_ms";
   auto delay_ms = getYamlEntryValue<int>(rcl_param, key);
+  if (!delay_ms) {
+    key = "readout_delay_ms";
+    delay_ms = getYamlEntryValue<int>(rcl_param, key);
+  }
   checkParamFound(delay_ms, path, key);
 
   return delay_ms.value();


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Adds parsing of camera readout delay from Add-On ECU cameras.
Add-On ECU uses SXPF  individual parameters with a different syntax:
https://github.com/tier4/autoware_individual_params.j6_gen2/blob/f0a80a0303a68c1981a9ba2ed984a1551283cded/individual_params/config/j6_gen2_03/aip_x2_gen2/tier4-c2/camera8_sxpf.param.yaml#L7

Compared to standard cameras:
https://github.com/tier4/autoware_individual_params.j6_gen2/blob/f0a80a0303a68c1981a9ba2ed984a1551283cded/individual_params/config/j6_gen2_03/aip_x2_gen2/tier4-c2/readout_delay_0.param.yaml#L3

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
